### PR TITLE
fix: backend-v1 service targetPort mismatch causing connection refused

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes a targetPort mismatch in the backend-v1 service manifest. The targetPort was set to 8081, but backend containers listen on 8080. Fixing this resolves connection refused errors when frontend calls backend via the service.