### PR TITLE
Fix backend-v1 Service targetPort to match Deployment containerPort

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the backend-v1 Service by changing the targetPort from 8081 to 8080 to match the containerPort exposed by the backend-v1 Deployment containers. This fix resolves the issue of no endpoints being populated for the backend-v1 Service.