### PR TITLE
fix: correct targetPort to 8080 in backend-v1 service manifest

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the backend-v1 service manifest to ensure the targetPort matches the containerPort 8080 as defined in the backend-v1 deployment. This resolves the communication issue between frontend and backend-v1 services.