### PR TITLE
fix: correct backend-v1 service targetPort to 8080 to match pod container

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
Fixes the backend-v1 Service targetPort to 8080 matching the pod container port to resolve frontend connectivity issues.