### PR TITLE
fix: correct targetPort of backend-v1 Service to 8080 to match container port

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the backend-v1 Service definition by changing the targetPort from 8081 to 8080 to correctly match the container port the backend pod is listening on. This resolves connectivity issues with the frontend application.